### PR TITLE
Fix summary on running a single test

### DIFF
--- a/rats.el
+++ b/rats.el
@@ -118,17 +118,17 @@
   "Run `go test', or if TEST is provided, run only that test."
   (let ((go-command (executable-find rats-go-executable-name)))
     (if go-command
-        (let* ((output-buffer-name "*rats-test*") 
-               (arguments '("test" "-v"))
-               (full-args (append arguments))
+        (let* ((output-buffer-name "*rats-test*")
+               (go-args (if (s-present? test)
+                            (list "test" "-v" "-run" test)
+                          (list "test" "-v")))
                (inhibit-read-only t))
           (when (get-buffer output-buffer-name)
             (with-current-buffer (get-buffer output-buffer-name)
               (erase-buffer)))
           (let ((output-buffer (get-buffer-create output-buffer-name)))
-            (call-process "go" nil output-buffer nil "test" "-v"
-                          (if (s-present? test) "-run" "")
-                          (if (s-present? test) test ""))
+            (apply #'call-process "go" nil output-buffer nil go-args)
+
             (with-current-buffer output-buffer
               (compilation-mode)
               (if (rats--failed-p (buffer-string))

--- a/rats.el
+++ b/rats.el
@@ -130,13 +130,13 @@
                           (if (s-present? test) "-run" "")
                           (if (s-present? test) test ""))
             (with-current-buffer output-buffer
+              (compilation-mode)
               (if (rats--failed-p (buffer-string))
                   `((err . ,(rats--format-failure (buffer-string))))
                 (if (s-present? test)
                     (or (rats--get-test-results (buffer-string) test)
                         `((err . ,(format "The test %s was not run." test))))  
-                  (rats--parse-results (buffer-string))))
-              (compilation-mode))))
+                  (rats--parse-results (buffer-string)))))))
       `((err . ,(format "`%s' command not found in PATH!" rats-go-executable-name))))))
 
 (defun rats--report-result (result &optional name)


### PR DESCRIPTION
My previous PR broke the summary when running a single test. This was because `compilation-mode` prevented us returning the result of the test run.

Also refactors two unused variables.